### PR TITLE
Add new endpoint for creating new shipping rate

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,15 +1,22 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
 
 import Control.Exception
+import Control.Exception.Base (try)
 import Control.Monad.Trans.Class
 import DB
 import Data.Aeson hiding (json)
 import Data.Text
+import Database.SQLite.Simple (ToRow (toRow))
 import qualified Database.SQLite.Simple as SQLite
+import Debug.Trace
+import GHC.Generics (Generic)
 import Network.HTTP.Types
+import Network.Wai.Middleware.RequestLogger
 import Web.Scotty
 
 data ShippingRate = ShippingRate Text Text
@@ -24,10 +31,24 @@ instance ToJSON ShippingRate where
         "express" .= exp
       ]
 
+data ShippingRateForm = ShippingRateForm
+  { name :: Text,
+    code :: Text,
+    regular_shipping_rate :: Text,
+    express_shipping_rate :: Text
+  }
+  deriving (Show, Eq, Generic, FromJSON)
+
+instance SQLite.ToRow ShippingRateForm where
+  toRow (ShippingRateForm name code regular_shipping_rate express_shipping_rate) =
+    toRow (name, code, regular_shipping_rate, express_shipping_rate)
+
 main :: IO ()
 main = do
   c <- initDB
-  (`finally` SQLite.close c) . scotty 3000 $
+  (`finally` SQLite.close c) . scotty 8080 $ do
+    middleware logStdoutDev
+
     get "/shipping_rates" $ do
       country_code :: Text <- param "country_code"
       rate :: [ShippingRate] <-
@@ -45,3 +66,25 @@ main = do
         _ -> do
           status internalServerError500
           json $ object ["error" .= String "Something went wrong"]
+    post "/shipping_rates" $ do
+      body' <- body
+      case eitherDecode body' of
+        Left err -> do
+          status badRequest400
+          json $ object ["error" .= String (pack $ "invalid input" <> show err)]
+        Right (form :: ShippingRateForm) -> do
+          result :: Either SomeException () <-
+            lift $
+              try $
+                SQLite.execute
+                  c
+                  "INSERT INTO country \
+                  \(name, code, regular_shipping_rate, regular_shipping_rate) \
+                  \VALUES (?, ?, ?, ?)"
+                  form
+          case result of
+            Left ex -> do
+              status badRequest400
+              json $ object ["error" .= String (pack $ show ex)]
+            Right _ -> do
+              status ok200

--- a/bellroy-tech-team-haskell-trial.cabal
+++ b/bellroy-tech-team-haskell-trial.cabal
@@ -19,6 +19,7 @@ executable tech-team-haskell-trial
     , sqlite-simple  ^>=0.4.18.0
     , text           ^>=1.2.4.1 || ^>=2.0.1
     , transformers   >=0.5.6.2  && <0.7
+    , wai-extra
 
   hs-source-dirs:   app
   default-language: Haskell2010


### PR DESCRIPTION
This PR is to add a new endpoint "POST /shipping_rates" to create new shipping rate, it uses `Parse, don't validate` to parse the user input and convert it into a `ShippingRateForm`