### PR TITLE
Dependency updates 2025-12-08

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755457263,
-        "narHash": "sha256-R//8BJCL7LcjZbe2u2PD//Uipa+SEQoJY9OJHVQmWvA=",
+        "lastModified": 1760309387,
+        "narHash": "sha256-e0lvQ7+B1Y8zjykYHAj9tBv10ggLqK0nmxwvMU3J0Eo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "762eec09c0e9efc19f456a1970e11a5b229ac9ce",
+        "rev": "6cd95994a9c8f7c6f8c1f1161be94119afdcb305",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760309387,
-        "narHash": "sha256-e0lvQ7+B1Y8zjykYHAj9tBv10ggLqK0nmxwvMU3J0Eo=",
+        "lastModified": 1765100908,
+        "narHash": "sha256-TXTImfTZmOYnS+AemOXiM7WDaeniuRHSruw3k+v+BCY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6cd95994a9c8f7c6f8c1f1161be94119afdcb305",
+        "rev": "9393af3b506fc38ff805cef7baf912e97d1f4ed3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updated Nix flake (nixpkgs from 2025-10-12 to 2025-12-07)
- Verified cabal packages are current for GHC 9.8.4
- Confirmed stack.yaml uses latest LTS 23.28

## Dependencies reviewed
- All Haskell package versions are appropriate for GHC 9.8.4
- Stack LTS snapshot already at latest for GHC 9.8.4
- No breaking changes

## Test plan
- [x] Verify project builds with `cabal build`
- [x] Verify project builds with `stack build`
- [x] Run tests with `cabal test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)